### PR TITLE
dsp/convol/cmplx: Fix vanity import path

### DIFF
--- a/convol/cmplx/doc.go
+++ b/convol/cmplx/doc.go
@@ -3,4 +3,4 @@
 
 // Package cmplx provides convolution implementations for complex kernels and
 // sequences.
-package cmplx /* import "zikichombo.org/dsp/cmplx" */
+package cmplx /* import "zikichombo.org/dsp/convol/cmplx" */


### PR DESCRIPTION
@wsc1 Is "zikichombo.org/dsp/convol/cmplx" the intended vanity
import path, or "zikichombo.org/dsp/cmplx"?

This PR assumes the former.

Fixes #6.